### PR TITLE
changed DEPEND for new dev-lang/perl ebuilds without "build" flag

### DIFF
--- a/eclass/perl-module.eclass
+++ b/eclass/perl-module.eclass
@@ -28,7 +28,7 @@ case "${EAPI:-0}" in
 
 		case "${GENTOO_DEPEND_ON_PERL:-yes}" in
 			yes)
-				DEPEND="dev-lang/perl[-build]"
+				DEPEND="( >=dev-lang/perl-5.16 <dev-lang/perl-5.16[-build] )"
 				RDEPEND="${DEPEND}"
 				;;
 		esac


### PR DESCRIPTION
dev-lang/perl builds newer than 5.16 does not have 'build' flag
