### PR TITLE
Removed unused category

### DIFF
--- a/profiles/categories
+++ b/profiles/categories
@@ -1,4 +1,3 @@
 dev-perl
-net-analyzer
 perl-core
 virtual


### PR DESCRIPTION
The categories file contain an unused category. It breaks Gentoo::Overlay module which expects every category having a directory in the overlay. As there are no net-analyzer packages in the repo I suggest removing the category completely.